### PR TITLE
Clean up the math module

### DIFF
--- a/example/1/game.js
+++ b/example/1/game.js
@@ -51,7 +51,6 @@ let dir = 1;
 //
 // const plane = new Cervus.shapes.Plane({
 //   material: material,
-//   color: Cervus.math.hex_to_vec('#CCCCCC')
 // });
 //
 // plane.position[2] = -50;
@@ -71,7 +70,6 @@ game.add(plane3);
 //
 // const plane4 = new Cervus.shapes.Plane({
 //   material: material,
-//   color: Cervus.math.hex_to_vec('#00FF00')
 // });
 //
 // plane4.position[1] = -15;

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -1,8 +1,7 @@
-import { gl, canvas } from './context.js';
-import { hex_to_vec } from '../misc/utils.js';
-import { zero_vector } from '../misc/defaults.js';
-import { math } from './math.js';
-import { Entity } from './entity.js';
+import { gl, canvas } from './context';
+import { hex_to_vec } from '../utils';
+import { vec3, mat4, to_radian } from './math';
+import { Entity } from './entity';
 
 const default_options = {
   width: 800,
@@ -12,7 +11,7 @@ const default_options = {
   autostart: true,
   keyboard_controlled_camera: false,
   clear_color: '#FFFFFF',
-  light_position: zero_vector.slice(),
+  light_position: vec3.zero.slice(),
   light_intensity: 0.4
 };
 
@@ -28,12 +27,12 @@ class Game {
 
     this.camera.game = this;
 
-    this.projMatrix = math.mat4.create();
-    this.viewMatrix = math.mat4.create();
+    this.projMatrix = mat4.create();
+    this.viewMatrix = mat4.create();
 
-    math.mat4.perspective(
+    mat4.perspective(
       this.projMatrix,
-      math.to_radian(90),
+      to_radian(90),
       canvas.width / canvas.height,
       0.35,
       85.0

--- a/src/core/math.js
+++ b/src/core/math.js
@@ -1,8 +1,7 @@
+const V = Float32Array;
+
 import {
-  fromValues,
   normalize,
-  distance,
-  angle,
   subtract,
   add,
   scale,
@@ -17,9 +16,8 @@ import {
   perspective,
   multiply,
   translate,
-  rotate,
   fromRotationTranslationScale,
-  lookAt,
+  lookAt
 } from 'gl-matrix/src/gl-matrix/mat4';
 
 import {
@@ -30,39 +28,41 @@ import {
   normalize as quat_normalize
 } from 'gl-matrix/src/gl-matrix/quat';
 
-import { hex_to_vec } from '../misc/utils.js';
-
-export const math = {
-  vec3: {
-    from_values: fromValues,
-    normalize,
-    distance,
-    angle,
-    subtract,
-    add,
-    scale,
-    transform_mat4: transformMat4,
-    cross
-  },
-  mat4: {
-    create,
-    invert,
-    perspective,
-    multiply,
-    translate,
-    rotate,
-    compose: fromRotationTranslationScale,
-    look_at: lookAt,
-  },
-  quat: {
-    create: quat_create,
-    multiply: quat_multiply,
-    set_axes,
-    set_axis_angle: setAxisAngle,
-  },
-  to_radian: (a) => a * Math.PI / 180,
-  hex_to_vec
+export const vec3 = {
+  zero: V.of(0, 0, 0),
+  unit: V.of(1, 1, 1),
+  left: V.of(1, 0, 0),
+  up: V.of(0, 1, 0),
+  forward: V.of(0, 0, 1),
+  of: (...vals) => V.of(...vals),
+  normalize,
+  subtract,
+  add,
+  scale,
+  transform_mat4: transformMat4,
+  cross
 };
+
+export const mat4 = {
+  create,
+  invert,
+  perspective,
+  multiply,
+  translate,
+  compose: fromRotationTranslationScale,
+  look_at: lookAt,
+};
+
+export const quat = {
+  create: quat_create,
+  multiply: quat_multiply,
+  set_axes,
+  set_axis_angle: setAxisAngle,
+};
+
+export function to_radian(a) {
+  return a * Math.PI / 180;
+}
 
 // XXX gl-matrix has a bug in quat.setAxes:
 // https://github.com/toji/gl-matrix/issues/234

--- a/src/main.js
+++ b/src/main.js
@@ -1,13 +1,5 @@
-import { Game } from './core/game.js';
-import { Entity } from './core/entity.js';
-import { math } from './core/math';
-import { materials } from './materials/materials.js';
-import { shapes } from './shapes/shapes.js';
-
-export {
-  Game,
-  Entity,
-  shapes,
-  math,
-  materials
-}
+export { Game } from './core/game';
+export { Entity } from './core/entity';
+export { vec3, mat4, quat, to_radian } from './core/math';
+export { materials } from './materials/materials';
+export { shapes } from './shapes/shapes';

--- a/src/misc/defaults.js
+++ b/src/misc/defaults.js
@@ -1,4 +1,0 @@
-const zero_vector = [ 0, 0, 0 ];
-const unit_vector = [ 1, 1, 1 ]
-
-export { zero_vector, unit_vector }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-const hex_to_vec = (hex) => {
+export const hex_to_vec = (hex) => {
   if (hex.charAt(0) === '#') {
     hex = hex.substr(1);
   }
@@ -13,5 +13,3 @@ const hex_to_vec = (hex) => {
     return parseFloat((parseInt(el, 16) / 255).toFixed(1));
   });
 };
-
-export { hex_to_vec }


### PR DESCRIPTION
Fix #24.
Fix #34.

I removed `hex_to_vec` from the global `Cervus` API. @michalbe would you like to have `Cervus.utils` or are setters enough for the color use-case for now?