### PR TITLE
Make forward/left movement horizontal

### DIFF
--- a/example/4/game.js
+++ b/example/4/game.js
@@ -1,0 +1,37 @@
+/* global Cervus */
+
+const game = new Cervus.Game({
+  width: window.innerWidth,
+  height: window.innerHeight,
+  light_position: [-1, 2, 5],
+  light_intensity: 0.9
+  // fps: 1
+});
+
+// By default all entities face the user.
+// Rotate the camera to see the scene.
+game.camera.position = [0, 3, 5];
+game.camera.rotate_rl(Math.PI);
+game.camera.keyboard_controlled = true;
+
+const plane = new Cervus.shapes.Plane({
+  material: Cervus.materials.phong,
+  color: "#eeeeee",
+  scale: [100, 1, 100]
+});
+game.add(plane);
+
+const group = new Cervus.Entity({
+  position: [0, 1, 0],
+  // scale: [2, 2, 2],
+});
+group.rotate_along([0, 1, 0], Math.PI/2);
+game.add(group);
+
+const cube = new Cervus.shapes.Box({
+  material: Cervus.materials.phong,
+  color: "#bada55",
+  position: [0, 1, 0]
+});
+cube.rotate_along([0, 1, 0], Math.PI/2);
+group.add(cube);

--- a/example/4/index.html
+++ b/example/4/index.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <meta charset="utf8">
+
+  <title>Cervus 0.1.0</title>
+  <style>
+    html, body {
+      padding: 0;
+      margin: 0;
+      overflow: hidden
+    }
+  </style>
+</head>
+<body>
+  <script src="../../cervus.js"></script>
+  <script src="game.js"></script>
+</body>

--- a/src/core/entity.js
+++ b/src/core/entity.js
@@ -36,7 +36,7 @@ class Entity {
   constructor(options) {
     this.matrix = mat4.create();
     this.world_matrix = mat4.create();
-    this.world_to_local = mat4.create();
+    this.world_to_self = mat4.create();
 
     this._scale = vec3.unit.slice();
     this._rotation = quat.create();
@@ -127,7 +127,7 @@ class Entity {
   look_at(target_position) {
     // Find the direction we're looking at. target_position must be given in
     // the current entity's coordinate space.  Use target's world_matrix and
-    // the current entity's world_to_local to go from target's space to the
+    // the current entity's world_to_self to go from target's space to the
     // current entity space.
     const forward = vec3.zero.slice();
     vec3.subtract(forward, target_position, this.position);
@@ -268,7 +268,7 @@ class Entity {
       this.world_matrix = this.matrix.slice();
     }
 
-    mat4.invert(this.world_to_local, this.world_matrix);
+    mat4.invert(this.world_to_self, this.world_matrix);
 
     this.entities.forEach(entity => entity.update(tick_length));
   }

--- a/src/core/entity.js
+++ b/src/core/entity.js
@@ -209,8 +209,8 @@ class Entity {
 
     // Simulate mouse deltas for rotation.
     const mouse_delta = {
-      x: (yl ? KEY_ROTATION_DELTA : 0) - (yr ? KEY_ROTATION_DELTA : 0),
-      y: (pu ? KEY_ROTATION_DELTA : 0) - (pd ? KEY_ROTATION_DELTA : 0),
+      x: yl * KEY_ROTATION_DELTA - yr * KEY_ROTATION_DELTA,
+      y: pu * KEY_ROTATION_DELTA - pd * KEY_ROTATION_DELTA,
     };
 
     this.handle_mouse(tick_length, mouse_delta);
@@ -250,7 +250,7 @@ class Entity {
       const current_dirs = {};
 
       for (const [key_code, dir] of Object.entries(this.dir_desc)) {
-        current_dirs[dir] = this.game.keys[key_code];
+        current_dirs[dir] = this.game.get_key(key_code);
       }
 
       this.handle_keys(tick_length, current_dirs);

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -114,11 +114,17 @@ class Game {
   }
 
   key_down(e) {
-    this.keys[e.keyCode] = true;
+    this.keys[e.keyCode] = 1;
   }
 
   key_up(e) {
-    this.keys[e.keyCode] = false
+    this.keys[e.keyCode] = 0
+  }
+
+  get_key(key_code) {
+    // Make sure we return 0 for undefined, i.e. keys we haven't seen
+    // pressed at all.
+    return this.keys[key_code] || 0;
   }
 
   mouse_move(e) {

--- a/src/core/math.js
+++ b/src/core/math.js
@@ -16,7 +16,6 @@ import {
   invert,
   perspective,
   multiply,
-  translate,
   fromRotationTranslationScale,
   lookAt
 } from 'gl-matrix/src/gl-matrix/mat4';
@@ -50,7 +49,6 @@ export const mat4 = {
   invert,
   perspective,
   multiply,
-  translate,
   compose: fromRotationTranslationScale,
   look_at: lookAt,
 };


### PR DESCRIPTION
The forward/backward and the left/right keyboard movement should move the entity in the horizontal plane (relative to the parent).  In other words, even when the object is looking up at an angle, the forward key should move it parallel to the parent's XZ plane ("the ground").

I also made the up/down movement always move the entity in the parent's Y axis regardless of the entity's pitch.

Also fixes #38.