### PR TITLE
Remove Babel from the build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "eslint": "^3.19.0",
     "eslint-config-defaults": "^9.0.0",
     "rollup": "^0.49.0",
-    "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-closure-compiler-js": "^1.0.5",
     "rollup-plugin-livereload": "^0.4.0",
     "rollup-plugin-node-resolve": "^3.0.0",

--- a/rollup-dev.js
+++ b/rollup-dev.js
@@ -1,5 +1,4 @@
 import resolve from 'rollup-plugin-node-resolve';
-import babel from 'rollup-plugin-babel';
 import serve from 'rollup-plugin-serve'
 import livereload from 'rollup-plugin-livereload'
 
@@ -12,9 +11,6 @@ export default {
   },
   plugins: [
     resolve(),
-    babel({
-      exclude: 'node_modules/**'
-    }),
     serve({
       // open: true,
       contentBase: ['example', 'dist']

--- a/rollup-prod.js
+++ b/rollup-prod.js
@@ -1,5 +1,4 @@
 import resolve from 'rollup-plugin-node-resolve';
-import babel from 'rollup-plugin-babel';
 import closure from 'rollup-plugin-closure-compiler-js';
 
 export default {
@@ -11,9 +10,6 @@ export default {
   },
   plugins: [
     resolve(),
-    babel({
-      exclude: 'node_modules/**'
-    }),
     closure(),
   ],
 };


### PR DESCRIPTION
Cervus is meant to be used by importing individual modules into the
codebase.  The build pipeline (Rollup and Babel) is useful for debugging
and demos in the example/ directory.

Since the evergreen browsers have very good ES2015+ support, removing
Babel makes it easier to debug code in devtools: the running code looks
much more like the code file source.

Babel also makes the built version of Cervus bigger (size with Babel:
9.56K, size without: 8.79K).  This won't impact the real use-cases, but
it still skews our "Size gzipped" estimate reported by `npm run prod`.