### PR TITLE
Use babel-minify in lieu of closure-compiler-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint": "^3.19.0",
     "eslint-config-defaults": "^9.0.0",
     "rollup": "^0.49.0",
-    "rollup-plugin-closure-compiler-js": "^1.0.5",
+    "rollup-plugin-babel-minify": "^3.1.2",
     "rollup-plugin-livereload": "^0.4.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-serve": "^0.3.0"

--- a/rollup-prod.js
+++ b/rollup-prod.js
@@ -1,5 +1,5 @@
 import resolve from 'rollup-plugin-node-resolve';
-import closure from 'rollup-plugin-closure-compiler-js';
+import minify from 'rollup-plugin-babel-minify';
 
 export default {
   input: 'index.js',
@@ -10,6 +10,6 @@ export default {
   },
   plugins: [
     resolve(),
-    closure(),
+    minify({ comments: false }),
   ],
 };


### PR DESCRIPTION
Babel-minify (previously: babili) has been the discovery du jour. I tried using it for Cervus as well and the results are stunning:

closure-compiler-js:

    created dist/cervus.min.js in 8.7s
    Size gzipped: 11.594K
    npm run prod  13,63s user 0,24s system 149% cpu 9,263 total

babel-minify:

    created dist/cervus.min.js in 1.6s
    Size gzipped: 7.502K
    npm run prod  2,64s user 0,09s system 126% cpu 2,157 total

I realize that bundling a minified version is not the primary use-case for Cervus. At the same time it's great to have a quick way to run the numbers and see how lightweight it is.