### PR TITLE
Remove get_entities_by_component in favor of game.components

### DIFF
--- a/core/game.js
+++ b/core/game.js
@@ -149,7 +149,7 @@ export class Game {
     this.listeners = new Map();
     this.keys = {};
     this.mouse_delta = {x: 0, y: 0};
-    this.entities_by_component = new WeakMap();
+    this.components = new WeakMap();
   }
 
   destroy() {
@@ -250,10 +250,10 @@ export class Game {
     entity.game = this;
 
     for (let component of entity.components.values()) {
-      if (!this.entities_by_component.has(component.constructor)) {
-        this.entities_by_component.set(component.constructor, new Set());
+      if (!this.components.has(component.constructor)) {
+        this.components.set(component.constructor, new Set());
       }
-      this.entities_by_component.get(component.constructor).add(entity);
+      this.components.get(component.constructor).add(component);
     }
 
     // Recursively track children.
@@ -266,17 +266,13 @@ export class Game {
     entity.game = null;
 
     for (let component of entity.components.values()) {
-      this.entities_by_component.get(component.constructor).delete(entity);
+      this.components.get(component.constructor).delete(component);
     }
 
     // Recursively untrack children.
     for (let child of entity.entities) {
       this.remove_from_components_sets(child);
     }
-  }
-
-  get_entities_by_component(component) {
-    return Array.from(this.entities_by_component.get(component));
   }
 
   add(entity) {

--- a/materials/phong.js
+++ b/materials/phong.js
@@ -89,18 +89,18 @@ export class PhongMaterial extends Material {
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffers.indices);
     gl.drawElements(this.draw_mode, buffers.qty, gl.UNSIGNED_SHORT, 0);
 
-    const lights = game.get_entities_by_component(Light);
+    const lights = Array.from(game.components.get(Light));
     const lights_count = lights.length;
     let light_position = new Float32Array(lights_count * 3);
     let light_color = new Float32Array(lights_count * 3);
     let light_intensity = new Float32Array(lights_count);
 
     for (let i = 0; i < lights_count; i++) {
-      let light_transform = lights[i].get_component(Transform);
+      let light_transform = lights[i].entity.get_component(Transform);
       let world_position = light_transform.world_matrix.slice(12, 15);
       light_position.set(world_position, i * 3);
-      light_color.set(lights[i].get_component(Light).color_vec, i * 3);
-      light_intensity[i] = lights[i].get_component(Light).intensity;
+      light_color.set(lights[i].color_vec, i * 3);
+      light_intensity[i] = lights[i].intensity;
     }
 
     gl.uniform1i(this.uniforms.al, lights_count);


### PR DESCRIPTION
`game.components.get()` may now be used to get sets of component instances by constructor. Use `component.entity` to get to the entity containing the instance.